### PR TITLE
Use opacity instead of listenable

### DIFF
--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -124,8 +124,8 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
 
     // We want to have the newly animating (fading in) views on top.
     transitions.sort((FadeTransition a, FadeTransition b) {
-      final Animation<double> aAnimation = a.listenable;
-      final Animation<double> bAnimation = b.listenable;
+      final Animation<double> aAnimation = a.opacity;
+      final Animation<double> bAnimation = b.opacity;
       final double aValue = aAnimation.value;
       final double bValue = bAnimation.value;
       return aValue.compareTo(bValue);


### PR DESCRIPTION
## Issue
No issue(Should I make the issue before PR?)

## Overview
Due to this PR https://github.com/flutter/flutter/pull/14155, latest version of FadeTransition inherit `SingleChildRenderObjectWidget`.
So we should use `opacity` instead of `listenable`.


## Screenshot
