### PR TITLE
add missing disposings

### DIFF
--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -78,6 +78,16 @@ class _MyHomePageState extends State<MyHomePage> with TickerProviderStateMixin {
   int _currentIndex = 0;
   List<PageContainer> _pages;
 
+  @override
+  void dispose() {
+    if (_pages != null) {
+      for (PageContainer container in _pages) {
+        container.controller.dispose();
+      }
+    }
+    super.dispose();
+  }
+  
   List<PageContainer> _createPages() {
     return <PageContainer>[
       new PageContainer(

--- a/lib/ui/sessions/all_sessions.dart
+++ b/lib/ui/sessions/all_sessions.dart
@@ -30,13 +30,16 @@ class AllSessionsPageState extends State<AllSessionsPage>
   }
 
   void setRooms(List<Room> rooms) {
-    setState(() => _rooms = rooms);
+    setState(() {
+      _rooms = rooms;
+      
+      _controller?.dispose();
+      _controller = new TabController(vsync: this, length: _rooms.length);
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    _controller = new TabController(vsync: this, length: _rooms.length);
-
     if (_rooms.isEmpty) {
       return new Center(
         child: const CircularProgressIndicator(),

--- a/lib/ui/sessions/session_detail.dart
+++ b/lib/ui/sessions/session_detail.dart
@@ -64,6 +64,12 @@ class _SessionDetailState extends State<SessionDetail> {
       }
     });
   }
+  
+  @override
+  void dispose() {
+    _hideFabController.dispose();
+    super.dispose();
+  }
 
   List<Widget> _buildSpeakerRows(
       List<Speaker> speakers, TextStyle speakerNameStyle) {


### PR DESCRIPTION
- _MyHomePageState: add `dispose` method to dispose `PageContailer.controller`
- _SessionDetailState: add `dispose` method to dispose `ScrollController`
- AllSessionsPageState: move creating `TabController` to `setRoom` because `build` may be called several times. And dispose previous `TabController`.