### PR TITLE
Adopt flutter version 0.3.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,9 +14,9 @@ if (flutterRoot == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def keystorePropertiesFile = rootProject.file("key.properties")
-def keystoreProperties = new Properties()
-keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+//def keystorePropertiesFile = rootProject.file("key.properties")
+//def keystoreProperties = new Properties()
+//keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 
 android {
     compileSdkVersion 27
@@ -36,19 +36,19 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
-    signingConfigs {
-        release {
-            keyAlias keystoreProperties['keyAlias']
-            keyPassword keystoreProperties['keyPassword']
-            storeFile file(keystoreProperties['storeFile'])
-            storePassword keystoreProperties['storePassword']
-        }
-    }
+//    signingConfigs {
+//        release {
+//            keyAlias keystoreProperties['keyAlias']
+//            keyPassword keystoreProperties['keyPassword']
+//            storeFile file(keystoreProperties['storeFile'])
+//            storePassword keystoreProperties['storePassword']
+//        }
+//    }
 
     buildTypes {
         release {
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.release
+//            signingConfig signingConfigs.release
         }
 
         profile {

--- a/lib/i18n/strings.dart
+++ b/lib/i18n/strings.dart
@@ -9,7 +9,7 @@ class Strings {
     final String name =
         locale.countryCode.isEmpty ? locale.languageCode : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
-    return initializeMessages(localeName).then((Null _) {
+    return initializeMessages(localeName).then((dynamic _) {
       Intl.defaultLocale = localeName;
       return new Strings();
     });

--- a/lib/models/session.dart
+++ b/lib/models/session.dart
@@ -50,7 +50,7 @@ class Session {
     var endsAt = DateTime.parse(json['endsAt']);
     var isServiceSession = json['isServiceSession'];
     var isPlenumSession = json['isPlenumSession'];
-    var speakers = [];
+    List<Speaker> speakers = [];
     var room = roomMap[json['roomId']];
 
     DurationType durationType;

--- a/lib/models/speaker.dart
+++ b/lib/models/speaker.dart
@@ -35,12 +35,12 @@ class Speaker {
     var isTopSpeaker = json['isTopSpeaker'];
     var fullName = json['fullName'];
 
-    var sessions = [];
+    List<Session> sessions = [];
     for (var sessionId in json['sessions']) {
       sessions.add(sessionMap[sessionId]);
     }
 
-    var links = [];
+    List<Link> links = [];
     for (var link in json['links']) {
       links.add(Link.fromJson(link));
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,11 +12,11 @@ dependencies:
   uri: 0.7.0 # flutter_test depends on this version
   url_launcher: "^2.0.1"
 
-  google_sign_in: 2.0.1
+  google_sign_in: 2.1.1
   firebase_auth: 0.4.3
   firebase_analytics: 0.2.2
   cloud_firestore: 0.2.9
-  shared_preferences: 0.3.2
+  shared_preferences: 0.3.3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   google_sign_in: 2.0.1
   firebase_auth: 0.4.3
   firebase_analytics: 0.2.2
-  cloud_firestore: 0.2.6
+  cloud_firestore: 0.2.9
   shared_preferences: 0.3.2
 
   # The following adds the Cupertino Icons font to your application.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  mockito: 2.2.3
 
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
## Overview

This PR resolve some errors on Flutter version 0.3.1.

## Environment

Flutter 0.3.1 • channel beta • https://github.com/flutter/flutter.git
Framework • revision 12bbaba9ae (11 days ago) • 2018-04-19 23:36:15 -0700
Engine • revision 09d05a3891
Tools • Dart 2.0.0-dev.48.0.flutter-fe606f890b

## Detail

- commented out about release-key signing information in build.gradle  see issue #64 
- update cloud_firestore version caused SDK version constraint
- add mockito dependency for test
- update google_sign_in version to fix type mismatch on run-time
- update shared_preferences version to fix type mismatch on run-time
- fix type mismatch error telled from dart analysis

